### PR TITLE
add x_deprecated => 1 to metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,3 +35,5 @@ filenames = Makefile.PL
 filenames = callparser1.h
 
 [Git::Contributors]
+
+[Deprecated]

--- a/dist.ini
+++ b/dist.ini
@@ -34,4 +34,4 @@ Capture::Tiny = 0
 filenames = Makefile.PL
 filenames = callparser1.h
 
-[ContributorsFromGit]
+[Git::Contributors]


### PR DESCRIPTION
..which is what all the cool kids are doing nowadays, to make it easier to find deprecated distributions via static analysis
