### PR TITLE
Added [Deprecated] so the dist metadata has x_deprecated => 1

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for Parse-Keyword
 
 {{$NEXT}}
+      - Added [Deprecated] to dist.ini, so the META.* files will have
+        x_deprecated => 1, making it easier for tools to identify dist
+        as deprecated.
 
 0.08  2013-10-10
       - doc tweaks to make the deprecation notice more visible

--- a/dist.ini
+++ b/dist.ini
@@ -34,4 +34,6 @@ Capture::Tiny = 0
 filenames = Makefile.PL
 filenames = callparser1.h
 
+[Deprecated]
+
 [ContributorsFromGit]


### PR DESCRIPTION
Hi Jesse,

This just adds the following to `dist.ini`:

```
[Deprecated]
```

Which sets `x_deprecated` to true in the dist's metadata.

This makes it easy for tools and CPAN auto processors to detect it as a deprecated dist.

See my [blog post](http://neilb.org/2015/01/17/deprecated-metadata.html) about it for background.

Cheers,
Neil
